### PR TITLE
[FEAT] Add metadata update to page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -23,3 +23,16 @@
   margin: auto;
   width: 100%;
 }
+
+.metadata-info {
+  font-size: 18px;
+  background-color: #fff3cd;
+  color: #856404;
+  border-color: #ffeeba;
+  width: 100%;
+  border: 1px solid transparent;
+  margin: 0 auto 15px;
+  text-align: center;
+  padding: 20px;
+  border-radius: 10px;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,23 @@
 import { useState, useEffect, Suspense } from "react";
+import { format } from "date-fns";
 import "./App.css";
 import createApiQuery from "./core/utils/create-api-query";
 import Events from "./components/events/events";
+import { Metadata } from "./core/types/metadata.interface";
 
 const baseApiUrl = "https://data.cityofnewyork.us/resource/tvpp-9vvx.json";
+const metaDataApiUrl =
+  "https://data.cityofnewyork.us/api/views/metadata/v1/tvpp-9vvx.json";
 
 function App() {
   const [data, setData] = useState<[]>([]);
+  const [metaData, setMetaData] = useState<Metadata>();
 
   const requestQuery = createApiQuery({ limit: "100" });
   const reqUrl = encodeURI(`${baseApiUrl}${requestQuery}`);
 
   useEffect(() => {
-    try {
+    async function getParadeData() {
       fetch(reqUrl)
         .then((res) => {
           return res.json();
@@ -20,9 +25,23 @@ function App() {
         .then((data) => {
           setData(data);
         });
-    } catch (error) {
-      throw new Error(`${error}`);
     }
+
+    getParadeData();
+  }, []);
+
+  useEffect(() => {
+    async function getMetadata() {
+      fetch(metaDataApiUrl)
+        .then((res) => {
+          return res.json();
+        })
+        .then((data) => {
+          setMetaData(data);
+        });
+    }
+
+    getMetadata();
   }, []);
 
   return (
@@ -32,10 +51,13 @@ function App() {
           <h1>Upcoming New York City Parades - 2025</h1>
           <p>
             Sourcing data from NYC Opendata, this page should display parades
-            with active permits filed. <span className="bolded-content">As per the data set page, permits for the
-            next month will only be part of the data set.</span> While not a
-            replacement for the&nbsp; 
-            <a href="https://www.nyc.gov/events/index.html" target="_blank"> 
+            with active permits filed.
+            <span className="bolded-content">
+              As per the data set page, permits for the next month will only be
+              part of the data set.
+            </span>
+            While not a replacement for the&nbsp;
+            <a href="https://www.nyc.gov/events/index.html" target="_blank">
               NYC Events page
             </a>
             , this is just a straight forward reference if you're looking for a
@@ -49,11 +71,22 @@ function App() {
             >
               NYC Opendata
             </a>
-            , no curation or selection of events is being done, anything tagged as "parade" will be listed.
+            , no curation or selection of events is being done, anything tagged
+            as "parade" will be listed.
           </p>
-          <p>This project is not associated with the City of New York. <a href="https://github.com/chinjon/nyc-events" target="_blank">This web page is open source, feel free to contribute.</a></p>
+          <p>
+            This project is not associated with the City of New York.
+            <a href="https://github.com/chinjon/nyc-events" target="_blank">
+              This web page is open source, feel free to contribute.
+            </a>
+          </p>
         </header>
         <Suspense>
+          <div className="metadata-info">This data set was updated by the NYC Office of CECM on:&nbsp; 
+            {metaData && metaData.dataUpdatedAt
+              ? format(new Date(metaData.dataUpdatedAt), "PPpp")
+              : ""}
+          </div>
           <div className="table-container">
             <Events eventsData={data} />
           </div>

--- a/src/core/types/metadata.interface.ts
+++ b/src/core/types/metadata.interface.ts
@@ -1,0 +1,3 @@
+export interface Metadata {
+  dataUpdatedAt?: string;
+}


### PR DESCRIPTION
Purpose of this PR is to add an alert-box to let users know when the metadata was updated by the managing nyc department.

Ref issue: https://github.com/chinjon/nyc-events/issues/2 