### PR TITLE
[CHORE] Turn off astro's pre-render

### DIFF
--- a/src/components/events/Events.astro
+++ b/src/components/events/Events.astro
@@ -1,4 +1,6 @@
 ---
+export const prerender = false;
+
 import EventCard from "../event-card/EventCard.astro";
 import type { Event } from "../../core/types/event.interface";
 import createApiQuery from "../../core/utils/create-api-query";


### PR DESCRIPTION
I believe I need this to ensure that every time a user hits the page a new request is made. If I don't the page is rendered only once and a new http req for the parade data is not done subsequent times.